### PR TITLE
added symbolic links

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -2,6 +2,9 @@ FROM debian:bookworm-slim
 
 RUN apt-get update -y && apt-get install -y build-essential cmake m4 automake peg libtool autoconf python3 python3-pip git peg lcov openssl libssl-dev
 
+# create symlinks
+RUN ln -s $(which aclocal) /usr/local/bin/aclocal-1.14 && ln -s $(which automake) /usr/local/bin/automake-1.14
+
 # install rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -2,6 +2,9 @@ FROM ubuntu:22.04 as builder
 
 RUN apt-get update -y && apt-get install -y curl build-essential cmake m4 automake peg libtool autoconf python3 python3-pip git peg lcov openssl libssl-dev
 
+# create symlinks
+RUN ln -s $(which aclocal) /usr/local/bin/aclocal-1.14 && ln -s $(which automake) /usr/local/bin/automake-1.14
+
 # install rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 


### PR DESCRIPTION
Required by `libcsv`

```sh
ln -s $(which aclocal) /usr/local/bin/aclocal-1.14
ln -s $(which automake) /usr/local/bin/automake-1.14
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added symbolic links for `aclocal` and `automake` in the Dockerfiles for Debian and Ubuntu.
	- Updated the environment variable `PATH` to include the Rust installation directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->