### PR TITLE
add curl

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,6 +1,6 @@
 FROM debian:bookworm-slim
 
-RUN apt-get update -y && apt-get install -y build-essential cmake m4 automake peg libtool autoconf python3 python3-pip git peg lcov openssl libssl-dev
+RUN apt-get update -y && apt-get install -y build-essential cmake m4 automake peg libtool autoconf python3 python3-pip git peg lcov openssl libssl-dev curl
 
 # create symlinks
 RUN ln -s $(which aclocal) /usr/local/bin/aclocal-1.14 && ln -s $(which automake) /usr/local/bin/automake-1.14

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -6,6 +6,9 @@ RUN yum update -y && \
   alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1 && \
   alternatives --auto python3
 
+# create symlinks
+RUN ln -s $(which aclocal) /usr/local/bin/aclocal-1.14 && ln -s $(which automake) /usr/local/bin/automake-1.14
+
 # install rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
@@ -27,7 +30,3 @@ RUN wget https://download.redis.io/redis-stable.tar.gz && \
   make && \
   make install && \
   cd ..
-
-# Add link to not found tools
-RUN ln -s aclocal /usr/bin/aclocal-1.14 && \
-  ln -s automake /usr/bin/automake-1.14

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -27,3 +27,7 @@ RUN wget https://download.redis.io/redis-stable.tar.gz && \
   make && \
   make install && \
   cd ..
+
+# Add link to not found tools
+RUN ln -s aclocal /usr/bin/aclocal-1.14 && \
+  ln -s automake /usr/bin/automake-1.14


### PR DESCRIPTION
fix #6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated Debian Docker image package installation to include `curl`.
	- Added symbolic links for `aclocal` and `automake` in the RHEL Docker image to ensure tool availability during the build process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->