### PR TITLE
remove symlinks

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -2,9 +2,6 @@ FROM debian:bookworm-slim
 
 RUN apt-get update -y && apt-get install -y build-essential cmake m4 automake peg libtool autoconf python3 python3-pip git peg lcov openssl libssl-dev curl
 
-# create symlinks
-RUN ln -s $(which aclocal) /usr/local/bin/aclocal-1.14 && ln -s $(which automake) /usr/local/bin/automake-1.14
-
 # install rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -6,9 +6,6 @@ RUN yum update -y && \
   alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1 && \
   alternatives --auto python3
 
-# create symlinks
-RUN ln -s $(which aclocal) /usr/local/bin/aclocal-1.14 && ln -s $(which automake) /usr/local/bin/automake-1.14
-
 # install rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -2,9 +2,6 @@ FROM ubuntu:22.04 as builder
 
 RUN apt-get update -y && apt-get install -y curl build-essential cmake m4 automake peg libtool autoconf python3 python3-pip git peg lcov openssl libssl-dev
 
-# create symlinks
-RUN ln -s $(which aclocal) /usr/local/bin/aclocal-1.14 && ln -s $(which automake) /usr/local/bin/automake-1.14
-
 # install rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 


### PR DESCRIPTION
fix #6 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed symbolic link creation for `aclocal` and `automake` in Debian, RHEL, and Ubuntu Dockerfiles
	- Simplified Docker image build process across different Linux distributions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->