### PR TITLE
fix: remove GCC 11 build stage and related configurations from Docker…

### DIFF
--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -1,14 +1,3 @@
-#########################################
-# Stage 1: Build GCC 11 on AlmaLinux 8 #
-#########################################
-FROM almalinux:8 as gcc-builder
-
-# Install module tools and GCC 11
-RUN dnf update -y && dnf install gcc-toolset-11 -y
-
-#########################################
-# Stage 2: Final UBI8 Image            #
-#########################################
 FROM redhat/ubi8 as builder
 
 # Install dependencies (without gcc, we'll copy it)
@@ -18,11 +7,6 @@ RUN yum update -y && \
     alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 && \
     alternatives --auto python3 && \
     yum clean all
-
-# Copy GCC 11 from AlmaLinux build
-COPY --from=gcc-builder /opt/rh /opt/rh
-ENV PATH=/opt/rh/gcc-toolset-11/root/usr/bin:$PATH
-ENV LD_LIBRARY_PATH=/opt/rh/gcc-toolset-11/root/usr/lib64:$LD_LIBRARY_PATH
 
 # Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y


### PR DESCRIPTION
fix #17 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Streamlined the RHEL8 container image by removing an unnecessary toolchain layer.
  * Cleaned up related environment configuration within the image.
  * Delivers a leaner image with fewer dependencies, potentially faster downloads and startup.
  * No changes to application behavior; existing workflows and usage remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->