### PR TITLE
fix: update CMake installation to version 3.25.1 in all Dockerfiles

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -2,11 +2,11 @@ FROM debian:bookworm-slim
 
 RUN apt-get update -y && apt-get install -y git wget build-essential lcov openssl libssl-dev python3 python3-venv rsync unzip curl m4 automake peg libtool autoconf python3-pip
 
-# Install up-to-date CMake
-RUN wget https://github.com/Kitware/CMake/releases/download/v4.2.0/cmake-4.2.0-linux-x86_64.sh && \
-    chmod +x cmake-4.2.0-linux-x86_64.sh && \
-    ./cmake-4.2.0-linux-x86_64.sh --skip-license --prefix=/usr/local && \
-    rm cmake-4.2.0-linux-x86_64.sh
+# Install CMake 3.25.1
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.25.1/cmake-3.25.1-linux-x86_64.sh && \
+    chmod +x cmake-3.25.1-linux-x86_64.sh && \
+    ./cmake-3.25.1-linux-x86_64.sh --skip-license --prefix=/usr/local && \
+    rm cmake-3.25.1-linux-x86_64.sh
 
 # install rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -5,11 +5,11 @@ RUN yum update -y && \
   alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 && \
   alternatives --auto python3
 
-# Install up-to-date CMake
-RUN wget https://github.com/Kitware/CMake/releases/download/v4.2.0/cmake-4.2.0-linux-x86_64.sh && \
-    chmod +x cmake-4.2.0-linux-x86_64.sh && \
-    ./cmake-4.2.0-linux-x86_64.sh --skip-license --prefix=/usr/local && \
-    rm cmake-4.2.0-linux-x86_64.sh
+# Install CMake 3.25.1
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.25.1/cmake-3.25.1-linux-x86_64.sh && \
+    chmod +x cmake-3.25.1-linux-x86_64.sh && \
+    ./cmake-3.25.1-linux-x86_64.sh --skip-license --prefix=/usr/local && \
+    rm cmake-3.25.1-linux-x86_64.sh
 
 # Enable gcc-toolset-12
 ENV PATH="/opt/rh/gcc-toolset-12/root/usr/bin:${PATH}"

--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -8,11 +8,11 @@ RUN yum update -y && \
     alternatives --auto python3 && \
     yum clean all
 
-# Install up-to-date CMake
-RUN wget https://github.com/Kitware/CMake/releases/download/v4.2.0/cmake-4.2.0-linux-x86_64.sh && \
-    chmod +x cmake-4.2.0-linux-x86_64.sh && \
-    ./cmake-4.2.0-linux-x86_64.sh --skip-license --prefix=/usr/local && \
-    rm cmake-4.2.0-linux-x86_64.sh
+# Install CMake 3.25.1
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.25.1/cmake-3.25.1-linux-x86_64.sh && \
+    chmod +x cmake-3.25.1-linux-x86_64.sh && \
+    ./cmake-3.25.1-linux-x86_64.sh --skip-license --prefix=/usr/local && \
+    rm cmake-3.25.1-linux-x86_64.sh
 
 # Enable gcc-toolset-12
 ENV PATH="/opt/rh/gcc-toolset-12/root/usr/bin:${PATH}"

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -2,11 +2,11 @@ FROM ubuntu:22.04 as builder
 
 RUN apt-get update -y && apt-get install -y git wget build-essential lcov openssl libssl-dev python3 python3-venv python3-dev unzip rsync curl m4 automake peg libtool autoconf python3-pip
 
-# Install up-to-date CMake
-RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null && \
-    echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null && \
-    apt-get update && \
-    apt-get install -y cmake
+# Install CMake 3.25.1
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.25.1/cmake-3.25.1-linux-x86_64.sh && \
+    chmod +x cmake-3.25.1-linux-x86_64.sh && \
+    ./cmake-3.25.1-linux-x86_64.sh --skip-license --prefix=/usr/local && \
+    rm cmake-3.25.1-linux-x86_64.sh
 
 # install rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CMake to version 3.25.1 across all Docker build environments (Debian, RHEL, RHEL 8, and Ubuntu), replacing the previous version 4.2.0. Installation procedures have been updated across all supported platforms, including a change in Ubuntu from repository-based package management to direct binary installation methods.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->