### PR TITLE
fix: update gcc-toolset to version 14 in Dockerfiles

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,7 +1,7 @@
 FROM redhat/ubi9 as builder
 
 RUN yum update -y && \
-  yum install -y wget autoconf automake python3.11 python3.11-pip libtool git make openssl-devel gcc-toolset-12 libstdc++-static diffutils && \
+  yum install -y wget autoconf automake python3.11 python3.11-pip libtool git make openssl-devel gcc-toolset-14 libstdc++-static diffutils && \
   alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 && \
   alternatives --auto python3
 
@@ -13,9 +13,9 @@ RUN ARCH=$(uname -m) && \
     ./cmake-3.25.1-linux-${ARCH}.sh --skip-license --prefix=/usr/local && \
     rm cmake-3.25.1-linux-${ARCH}.sh
 
-# Enable gcc-toolset-12
-ENV PATH="/opt/rh/gcc-toolset-12/root/usr/bin:${PATH}"
-ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-12/root/usr/lib64:${LD_LIBRARY_PATH}"
+# Enable gcc-toolset-14
+ENV PATH="/opt/rh/gcc-toolset-14/root/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-14/root/usr/lib64:${LD_LIBRARY_PATH}"
 
 # install rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -1,9 +1,9 @@
 FROM redhat/ubi8 as builder
 
-# Install dependencies including gcc-toolset-12
+# Install dependencies including gcc-toolset-14
 RUN yum update -y && \
     yum install -y wget autoconf automake python3.11 python3.11-pip \
-                   libtool git make openssl-devel libstdc++-static diffutils gcc-toolset-12 && \
+                   libtool git make openssl-devel libstdc++-static diffutils gcc-toolset-14 && \
     alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 && \
     alternatives --auto python3 && \
     yum clean all
@@ -16,9 +16,9 @@ RUN ARCH=$(uname -m) && \
     ./cmake-3.25.1-linux-${ARCH}.sh --skip-license --prefix=/usr/local && \
     rm cmake-3.25.1-linux-${ARCH}.sh
 
-# Enable gcc-toolset-12
-ENV PATH="/opt/rh/gcc-toolset-12/root/usr/bin:${PATH}"
-ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-12/root/usr/lib64:${LD_LIBRARY_PATH}"
+# Enable gcc-toolset-14
+ENV PATH="/opt/rh/gcc-toolset-14/root/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/opt/rh/gcc-toolset-14/root/usr/lib64:${LD_LIBRARY_PATH}"
 
 # Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build environment to use GCC 14 toolchain across supported platforms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->