### PR TITLE
fix: remove redundant zstd installation step in Dockerfile for Alpine

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -17,26 +17,17 @@ RUN apk add --no-cache --no-scripts \
     autoconf \
     openssl-dev \
     zlib-dev \
+    zstd \
     zstd-dev \
     zstd-static \
     rust \
     cargo \
+    cmake \
     bsd-compat-headers \
     linux-headers \
     build-base && \
     # Manually update CA certificates since we skipped triggers
     update-ca-certificates || true
-
-# Install cmake-3.25.1 from source
-RUN wget https://github.com/Kitware/CMake/releases/download/v3.25.1/cmake-3.25.1.tar.gz && \
-    tar -xzf cmake-3.25.1.tar.gz && \
-    cd cmake-3.25.1 && \
-    ./bootstrap --parallel=$(nproc) --prefix=/usr/local && \
-    make -j$(nproc) && \
-    make install && \
-    cd .. && \
-    rm -rf cmake-3.25.1 cmake-3.25.1.tar.gz && \
-    cmake --version
 
 # Activate pyenv
 RUN python3 -m venv /venv

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,14 +1,6 @@
 FROM debian:bookworm-slim
 
-RUN apt-get update -y && apt-get install -y git wget build-essential lcov openssl libssl-dev python3 python3-venv rsync unzip curl m4 automake peg libtool autoconf python3-pip
-
-# Install CMake 3.25.1
-RUN ARCH=$(uname -m) && \
-    if [ "$ARCH" = "aarch64" ]; then ARCH="aarch64"; else ARCH="x86_64"; fi && \
-    wget https://github.com/Kitware/CMake/releases/download/v3.25.1/cmake-3.25.1-linux-${ARCH}.sh && \
-    chmod +x cmake-3.25.1-linux-${ARCH}.sh && \
-    ./cmake-3.25.1-linux-${ARCH}.sh --skip-license --prefix=/usr/local && \
-    rm cmake-3.25.1-linux-${ARCH}.sh
+RUN apt-get update -y && apt-get install -y git wget build-essential lcov openssl libssl-dev python3 python3-venv rsync unzip curl m4 automake peg libtool autoconf python3-pip cmake
 
 # install rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,17 +1,9 @@
 FROM redhat/ubi9 as builder
 
 RUN yum update -y && \
-  yum install -y wget autoconf automake python3.11 python3.11-pip libtool git make openssl-devel gcc-toolset-14 libstdc++-static diffutils && \
+  yum install -y wget autoconf automake python3.11 python3.11-pip libtool git make openssl-devel gcc-toolset-14 libstdc++-static diffutils cmake && \
   alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 && \
   alternatives --auto python3
-
-# Install CMake 3.25.1
-RUN ARCH=$(uname -m) && \
-    if [ "$ARCH" = "aarch64" ]; then ARCH="aarch64"; else ARCH="x86_64"; fi && \
-    wget https://github.com/Kitware/CMake/releases/download/v3.25.1/cmake-3.25.1-linux-${ARCH}.sh && \
-    chmod +x cmake-3.25.1-linux-${ARCH}.sh && \
-    ./cmake-3.25.1-linux-${ARCH}.sh --skip-license --prefix=/usr/local && \
-    rm cmake-3.25.1-linux-${ARCH}.sh
 
 # Enable gcc-toolset-14
 ENV PATH="/opt/rh/gcc-toolset-14/root/usr/bin:${PATH}"

--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -3,18 +3,10 @@ FROM redhat/ubi8 as builder
 # Install dependencies including gcc-toolset-14
 RUN yum update -y && \
     yum install -y wget autoconf automake python3.11 python3.11-pip \
-                   libtool git make openssl-devel libstdc++-static diffutils gcc-toolset-14 && \
+                   libtool git make openssl-devel libstdc++-static diffutils gcc-toolset-14 cmake && \
     alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 && \
     alternatives --auto python3 && \
     yum clean all
-
-# Install CMake 3.25.1
-RUN ARCH=$(uname -m) && \
-    if [ "$ARCH" = "aarch64" ]; then ARCH="aarch64"; else ARCH="x86_64"; fi && \
-    wget https://github.com/Kitware/CMake/releases/download/v3.25.1/cmake-3.25.1-linux-${ARCH}.sh && \
-    chmod +x cmake-3.25.1-linux-${ARCH}.sh && \
-    ./cmake-3.25.1-linux-${ARCH}.sh --skip-license --prefix=/usr/local && \
-    rm cmake-3.25.1-linux-${ARCH}.sh
 
 # Enable gcc-toolset-14
 ENV PATH="/opt/rh/gcc-toolset-14/root/usr/bin:${PATH}"

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,14 +1,6 @@
 FROM ubuntu:22.04 as builder
 
-RUN apt-get update -y && apt-get install -y git wget build-essential lcov openssl libssl-dev python3 python3-venv python3-dev unzip rsync curl m4 automake peg libtool autoconf python3-pip
-
-# Install CMake 3.25.1
-RUN ARCH=$(uname -m) && \
-    if [ "$ARCH" = "aarch64" ]; then ARCH="aarch64"; else ARCH="x86_64"; fi && \
-    wget https://github.com/Kitware/CMake/releases/download/v3.25.1/cmake-3.25.1-linux-${ARCH}.sh && \
-    chmod +x cmake-3.25.1-linux-${ARCH}.sh && \
-    ./cmake-3.25.1-linux-${ARCH}.sh --skip-license --prefix=/usr/local && \
-    rm cmake-3.25.1-linux-${ARCH}.sh
+RUN apt-get update -y && apt-get install -y git wget build-essential lcov openssl libssl-dev python3 python3-venv python3-dev unzip rsync curl m4 automake peg libtool autoconf python3-pip cmake
 
 # install rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined container build setups by consolidating CMake and compression library installations, removing redundant install steps across distributions.
  * Added Rust toolchain installation and PATH update in affected builds.
  * Reduced unnecessary download/cleanup operations to improve build efficiency and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->