### PR TITLE
Add RHEL 9 and Amazon Linux support to Docker build workflow and create Dockerfile

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -16,6 +16,8 @@ jobs:
           - rhel
           - rhel8
           - rhel9
+          - amazonlinux2
+          - amazonlinux2023
           - alpine
 
     steps:

--- a/Dockerfile.amazonlinux2
+++ b/Dockerfile.amazonlinux2
@@ -1,0 +1,52 @@
+FROM amazonlinux:2 AS builder
+
+RUN set -eux; \
+    yum update -y; \
+    yum install -y \
+      git \
+      wget \
+      curl \
+      ca-certificates \
+      unzip \
+      rsync \
+      m4 \
+      automake \
+      libtool \
+      autoconf \
+      make \
+      diffutils \
+      which \
+      gcc \
+      gcc-c++ \
+      libstdc++-static \
+      openssl \
+      openssl-devel \
+      python3 \
+      python3-pip; \
+    if yum install -y cmake3; then \
+      ln -sf /usr/bin/cmake3 /usr/local/bin/cmake || true; \
+    else \
+      yum install -y cmake; \
+    fi; \
+    yum clean all; \
+    rm -rf /var/cache/yum
+
+# install rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+# add rust to path
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# install leg/geg
+ARG PEG_VERSION=0.1.19
+ARG PEG_SHA256=74d1b7b905dbbc1776502a4ccf9c38ad8b86c9f8e51b825214783eefd5cdc9af
+RUN set -eux; \
+  url="https://github.com/gpakosz/peg/archive/refs/tags/${PEG_VERSION}.tar.gz"; \
+  curl -fsSL -o peg.tar.gz "$url"; \
+  echo "${PEG_SHA256}  peg.tar.gz" | sha256sum -c -; \
+  tar -xzf peg.tar.gz; \
+  cd "peg-${PEG_VERSION}"; \
+  make; \
+  make install; \
+  cd ..; \
+  rm -rf "peg-${PEG_VERSION}" peg.tar.gz

--- a/Dockerfile.amazonlinux2023
+++ b/Dockerfile.amazonlinux2023
@@ -1,0 +1,46 @@
+FROM amazonlinux:2023 AS builder
+
+RUN set -eux; \
+    dnf update -y; \
+    dnf install -y \
+      git \
+      wget \
+      ca-certificates \
+      unzip \
+      rsync \
+      m4 \
+      automake \
+      libtool \
+      autoconf \
+      make \
+      diffutils \
+      which \
+      gcc \
+      gcc-c++ \
+      libstdc++-static \
+      openssl \
+      openssl-devel \
+      python3 \
+      python3-pip \
+      cmake; \
+    dnf clean all
+
+# install rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+# add rust to path
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# install leg/geg
+ARG PEG_VERSION=0.1.19
+ARG PEG_SHA256=74d1b7b905dbbc1776502a4ccf9c38ad8b86c9f8e51b825214783eefd5cdc9af
+RUN set -eux; \
+  url="https://github.com/gpakosz/peg/archive/refs/tags/${PEG_VERSION}.tar.gz"; \
+  wget -O peg.tar.gz "$url"; \
+  echo "${PEG_SHA256}  peg.tar.gz" | sha256sum -c -; \
+  tar -xzf peg.tar.gz; \
+  cd "peg-${PEG_VERSION}"; \
+  make; \
+  make install; \
+  cd ..; \
+  rm -rf "peg-${PEG_VERSION}" peg.tar.gz

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -16,12 +16,18 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # install leg/geg
-RUN wget https://www.piumarta.com/software/peg/peg-0.1.19.tar.gz && \
-  tar -xzvf peg-0.1.19.tar.gz && \
-  cd peg-0.1.19 && \
-  make && \
-  make install && \
-  cd ..
+ARG PEG_VERSION=0.1.19
+ARG PEG_SHA256=74d1b7b905dbbc1776502a4ccf9c38ad8b86c9f8e51b825214783eefd5cdc9af
+RUN set -eux; \
+  url="https://github.com/gpakosz/peg/archive/refs/tags/${PEG_VERSION}.tar.gz"; \
+  wget -O peg.tar.gz "$url"; \
+  echo "${PEG_SHA256}  peg.tar.gz" | sha256sum -c -; \
+  tar -xzf peg.tar.gz; \
+  cd "peg-${PEG_VERSION}"; \
+  make; \
+  make install; \
+  cd ..; \
+  rm -rf "peg-${PEG_VERSION}" peg.tar.gz
 
 # install redis
 # RUN wget https://download.redis.io/redis-stable.tar.gz && \

--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -17,11 +17,17 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Install PEG
-RUN wget https://www.piumarta.com/software/peg/peg-0.1.19.tar.gz && \
-    tar -xzvf peg-0.1.19.tar.gz && \
-    cd peg-0.1.19 && \
-    make && make install && \
-    cd .. && rm -rf peg-0.1.19*
+ARG PEG_VERSION=0.1.19
+ARG PEG_SHA256=74d1b7b905dbbc1776502a4ccf9c38ad8b86c9f8e51b825214783eefd5cdc9af
+RUN set -eux; \
+    url="https://github.com/gpakosz/peg/archive/refs/tags/${PEG_VERSION}.tar.gz"; \
+    wget -O peg.tar.gz "$url"; \
+    echo "${PEG_SHA256}  peg.tar.gz" | sha256sum -c -; \
+    tar -xzf peg.tar.gz; \
+    cd "peg-${PEG_VERSION}"; \
+    make && make install; \
+    cd ..; \
+    rm -rf "peg-${PEG_VERSION}" peg.tar.gz
 
 # # Install Redis
 # RUN wget https://download.redis.io/redis-stable.tar.gz && \

--- a/Dockerfile.rhel9
+++ b/Dockerfile.rhel9
@@ -16,12 +16,18 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # install leg/geg
-RUN wget https://www.piumarta.com/software/peg/peg-0.1.19.tar.gz && \
-  tar -xzvf peg-0.1.19.tar.gz && \
-  cd peg-0.1.19 && \
-  make && \
-  make install && \
-  cd ..
+ARG PEG_VERSION=0.1.19
+ARG PEG_SHA256=74d1b7b905dbbc1776502a4ccf9c38ad8b86c9f8e51b825214783eefd5cdc9af
+RUN set -eux; \
+  url="https://github.com/gpakosz/peg/archive/refs/tags/${PEG_VERSION}.tar.gz"; \
+  wget -O peg.tar.gz "$url"; \
+  echo "${PEG_SHA256}  peg.tar.gz" | sha256sum -c -; \
+  tar -xzf peg.tar.gz; \
+  cd "peg-${PEG_VERSION}"; \
+  make; \
+  make install; \
+  cd ..; \
+  rm -rf "peg-${PEG_VERSION}" peg.tar.gz
 
 # install redis
 # RUN wget https://download.redis.io/redis-stable.tar.gz && \

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Build images are available for multiple architectures (amd64, arm64) and operati
 - `falkordb/falkordb-build:alpine` - Alpine Linux based image
 - `falkordb/falkordb-build:rhel` - Red Hat UBI 9 based image
 - `falkordb/falkordb-build:rhel8` - Red Hat UBI 8 based image
+- `falkordb/falkordb-build:rhel9` - Red Hat UBI 9 based image
+- `falkordb/falkordb-build:amazonlinux2` - Amazon Linux 2 based image (glibc baseline for AL2)
+- `falkordb/falkordb-build:amazonlinux2023` - Amazon Linux 2023 based image
 
 ## Versioning
 


### PR DESCRIPTION
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added three new build targets (RHEL9, Amazon Linux 2, Amazon Linux 2023) to the image build matrix and introduced corresponding build configurations.
* **Documentation**
  * Updated available images and examples to include the three new build image tags.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
 
 **PR Summary by Typo**
------------

#### Overview
This PR introduces support for RHEL 9, Amazon Linux 2, and Amazon Linux 2023 within the Docker build workflow, expanding the range of supported operating systems for building Docker images. It also standardizes the installation method for `peg` across existing RHEL Dockerfiles.

#### Key Changes
- Added `rhel9`, `amazonlinux2`, and `amazonlinux2023` to the Docker build workflow in `.github/workflows/build-docker-image.yml`.
- Created new Dockerfiles (`Dockerfile.rhel9`, `Dockerfile.amazonlinux2`, `Dockerfile.amazonlinux2023`) to define the build environments for these new operating systems.
- Standardized the `peg` installation process in `Dockerfile.rhel` and `Dockerfile.rhel8` to use a more robust method with SHA256 checksum verification and version arguments.
- Updated `README.md` to reflect the newly supported Docker build images.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 154 (93.3%)   |
| Rework      | 11 (6.7%)     |
| Total Changes | 165         | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>