### PR TITLE
Add Make installation from source to Dockerfile for Amazon Linux 2

### DIFF
--- a/Dockerfile.amazonlinux2
+++ b/Dockerfile.amazonlinux2
@@ -37,6 +37,21 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 # add rust to path
 ENV PATH="/root/.cargo/bin:${PATH}"
 
+# upgrade make to latest from source (system make stays for bootstrap)
+ARG MAKE_VERSION=4.4.1
+ARG MAKE_SHA256=dd16fb1d67bfab79a72f5e8390735c49e3e8e70b4945a15ab1f81ddb78658fb3
+RUN set -eux; \
+  url="https://ftp.gnu.org/gnu/make/make-${MAKE_VERSION}.tar.gz"; \
+  curl -fsSL -o make.tar.gz "$url"; \
+  echo "${MAKE_SHA256}  make.tar.gz" | sha256sum -c -; \
+  tar -xzf make.tar.gz; \
+  cd "make-${MAKE_VERSION}"; \
+  ./configure; \
+  make -j"$(nproc)"; \
+  make install; \
+  cd ..; \
+  rm -rf "make-${MAKE_VERSION}" make.tar.gz
+
 # install leg/geg
 ARG PEG_VERSION=0.1.19
 ARG PEG_SHA256=74d1b7b905dbbc1776502a4ccf9c38ad8b86c9f8e51b825214783eefd5cdc9af


### PR DESCRIPTION
 **PR Summary by Typo**
------------

#### Overview
This PR updates the `Dockerfile.amazonlinux2` to install a newer version of `make` from source, addressing potential compatibility or feature requirements that the system's default `make` might not provide.

#### Key Changes
- Added a multi-step `RUN` command to download, verify, compile, and install `make` version 4.4.1 from its source.
- Introduced `ARG` declarations for `MAKE_VERSION` and `MAKE_SHA256` to ensure a specific, verified version of `make` is installed.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 15 (100.0%)   |
| Total Changes | 15          | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Docker build reliability by upgrading the make utility to a specific version during image construction, ensuring consistent build environments across deployments and reducing dependency on system-provided tools.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->