### PR TITLE
install cmake from source

### DIFF
--- a/Dockerfile.amazonlinux2
+++ b/Dockerfile.amazonlinux2
@@ -36,7 +36,7 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 ARG CMAKE_VERSION=3.27.9
 ARG CMAKE_SHA256=609a9b98572a6a5ea477f912cffb973109ed4d0a6a6b3f9e2353d2cdc048708e
 RUN set -eux; \
-  url="https://cmake.org/files/v3.27/cmake-${CMAKE_VERSION}.tar.gz"; \
+  url="https://cmake.org/files/v${CMAKE_VERSION%.*}/cmake-${CMAKE_VERSION}.tar.gz"; \
   curl -fsSL -o cmake.tar.gz "$url"; \
   echo "${CMAKE_SHA256}  cmake.tar.gz" | sha256sum -c -; \
   tar -xzf cmake.tar.gz; \


### PR DESCRIPTION
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Docker build to install CMake and Make from source with explicit version and checksum pins, replacing prior package-manager installs for more consistent, reproducible builds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
 
 **PR Summary by Typo**
------------

#### Overview
This PR updates the Dockerfile to install a newer version of CMake from source, replacing the previous method of installing system-provided CMake packages. This addresses the need for a more recent CMake version than what is available via `yum`.

#### Key Changes
- Removed the conditional `yum install cmake3` or `cmake` logic.
- Added steps to download, verify with SHA256, compile, and install CMake version 3.27.9 from its source.
- Introduced `CMAKE_VERSION` and `CMAKE_SHA256` as build arguments for better control over the installed CMake version.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 15 (75.0%)    |
| Churn       | 5 (25.0%)     |
| Total Changes | 20          | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>